### PR TITLE
Adding an install target for amdphdrs

### DIFF
--- a/amdphdrs/CMakeLists.txt
+++ b/amdphdrs/CMakeLists.txt
@@ -2,24 +2,24 @@
 ##
 ## The University of Illinois/NCSA
 ## Open Source License (NCSA)
-## 
+##
 ## Copyright (c) 2016, Advanced Micro Devices, Inc. All rights reserved.
-## 
+##
 ## Developed by:
-## 
+##
 ##                 AMD Research and AMD HSA Software Development
-## 
+##
 ##                 Advanced Micro Devices, Inc.
-## 
+##
 ##                 www.amd.com
-## 
+##
 ## Permission is hereby granted, free of charge, to any person obtaining a copy
 ## of this software and associated documentation files (the "Software"), to
 ## deal with the Software without restriction, including without limitation
 ## the rights to use, copy, modify, merge, publish, distribute, sublicense,
 ## and#or sell copies of the Software, and to permit persons to whom the
 ## Software is furnished to do so, subject to the following conditions:
-## 
+##
 ##  - Redistributions of source code must retain the above copyright notice,
 ##    this list of conditions and the following disclaimers.
 ##  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 ##    nor the names of its contributors may be used to endorse or promote
 ##    products derived from this Software without specific prior written
 ##    permission.
-## 
+##
 ## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -54,3 +54,9 @@ include_directories(${LIBELF_INCLUDE_DIRS})
 
 add_executable(amdphdrs amdphdrs.c)
 target_link_libraries(amdphdrs elf)
+
+install( TARGETS amdphdrs
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)


### PR DESCRIPTION
This adds the necessary logic to install the amdphdrs executable into the install location at 'make install' time