### PR TITLE
Update assembly examples for code object v2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,7 +49,7 @@ macro(asm_assemble f)
 add_custom_command(
   OUTPUT ${f}.o
   COMMAND
-    ${LLVM-MC} -arch=amdgcn -mcpu=fiji -filetype=obj -o ${f}.o ${CMAKE_CURRENT_SOURCE_DIR}/${f}.s
+    ${CLANG}  -x assembler -target amdgcn--amdhsa -mcpu=fiji -c -o ${f}.o ${CMAKE_CURRENT_SOURCE_DIR}/${f}.s
   DEPENDS ${f}.s
   COMMENT "Assembling ${f}.s to ${f}.o"
 )
@@ -59,9 +59,9 @@ macro(asm_link f)
 add_custom_command(
   OUTPUT ${f}.co
   COMMAND
-    ${AMDPHDRS} ${f}.o ${f}.co
+    ${CLANG} -target amdgcn--amdhsa ${f}.o -o ${f}.co
   DEPENDS ${f}.o
-  COMMENT "Linking ${f}.o to ${f}.co with amdphdrs"
+  COMMENT "Linking ${f}.o to ${f}.co with clang"
 )
 endmacro(asm_link)
 

--- a/examples/asm-kernel/asm-kernel.s
+++ b/examples/asm-kernel/asm-kernel.s
@@ -40,10 +40,10 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-.hsa_code_object_version 1,0
+.hsa_code_object_version 2,0
 .hsa_code_object_isa 8, 0, 3, "AMD", "AMDGPU"
 
-.hsatext
+.text
 .p2align 8
 .amdgpu_hsa_kernel hello_world
 

--- a/examples/gfx8/dpp_reduce.s
+++ b/examples/gfx8/dpp_reduce.s
@@ -44,10 +44,10 @@
 // Use DPP instructions to compute prefix sum in a wavefront.
 //
 
-.hsa_code_object_version 1,0
+.hsa_code_object_version 2,0
 .hsa_code_object_isa 8, 0, 3, "AMD", "AMDGPU"
 
-.hsatext
+.text
 .p2align 8
 .amdgpu_hsa_kernel hello_world
 

--- a/examples/gfx8/ds_bpermute.s
+++ b/examples/gfx8/ds_bpermute.s
@@ -46,10 +46,10 @@
 // arrays are passed as kernel arguments.
 //
 
-.hsa_code_object_version 1,0
+.hsa_code_object_version 2,0
 .hsa_code_object_isa 8, 0, 3, "AMD", "AMDGPU"
 
-.hsatext
+.text
 .p2align 8
 .amdgpu_hsa_kernel hello_world
 

--- a/examples/gfx8/s_memrealtime.s
+++ b/examples/gfx8/s_memrealtime.s
@@ -46,10 +46,10 @@
 // clocks to wait is passed as kernel argument.
 //
 
-.hsa_code_object_version 1,0
+.hsa_code_object_version 2,0
 .hsa_code_object_isa 8, 0, 3, "AMD", "AMDGPU"
 
-.hsatext
+.text
 .p2align 8
 .amdgpu_hsa_kernel hello_world
 


### PR DESCRIPTION
LLVM is migrating from v1 to v2.

Sorry, I meant to push this branch to my own repository and create the pull request from there, but anyway this updates all the assembly examples to use code object v2.  We have to wait to merge this until clang/llvm ads code object v2 support.